### PR TITLE
Introduce the Collection trait

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,0 +1,120 @@
+use std::hash::Hash;
+use std::collections::{HashSet, BTreeSet};
+
+/// This trait is meant to abstract any kind of collection
+/// (i.e. [`Vec`], [`HashSet`]).
+///
+/// This is particularly helpful when you want particular behavior
+/// when inserting elements, the [`Counter`] struct is a good example
+/// of a custom implementation of the [`Collection`] trait, it is used to only
+/// count the number of elements of a set operation.
+pub trait Collection<T> {
+
+    /// Insert one element into the collection.
+    fn push(&mut self, elem: T);
+
+    /// Extend the collection by cloning the elements.
+    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone;
+
+    /// Extend the collection by inserting the elements from the given [`Iterator`].
+    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T>;
+
+    /// Reserve enough space in the collection for `size` elements.
+    fn reserve(&mut self, _size: usize) { }
+}
+
+impl<T> Collection<T> for Vec<T> {
+    fn push(&mut self, elem: T) {
+        Vec::push(self, elem);
+    }
+
+    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
+        Vec::extend_from_slice(self, elems);
+    }
+
+    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
+        Extend::extend(self, elems);
+    }
+
+    fn reserve(&mut self, size: usize) {
+        Vec::reserve(self, size);
+    }
+}
+
+impl<T: Hash + Eq> Collection<T> for HashSet<T> {
+    fn push(&mut self, elem: T) {
+        HashSet::insert(self, elem);
+    }
+
+    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
+        Collection::extend(self, elems.iter().cloned());
+    }
+
+    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
+        Extend::extend(self, elems);
+    }
+
+    fn reserve(&mut self, size: usize) {
+        HashSet::reserve(self, size);
+    }
+}
+
+impl<T: Ord> Collection<T> for BTreeSet<T> {
+    fn push(&mut self, elem: T) {
+        BTreeSet::insert(self, elem);
+    }
+
+    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
+        Collection::extend(self, elems.iter().cloned());
+    }
+
+    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
+        Extend::extend(self, elems);
+    }
+}
+
+/// A [`Collection`] that only counts the final size of a set operation.
+///
+/// It is meant to be used to avoid unecessary allocations.
+///
+/// ```
+/// # use sdset::Error;
+/// # fn try_main() -> Result<(), Error> {
+/// use sdset::duo::OpBuilder;
+/// use sdset::{SetOperation, Set, SetBuf, Counter};
+///
+/// let a = Set::new(&[1, 2, 4, 6, 7])?;
+/// let b = Set::new(&[2, 3, 4, 5, 6, 7])?;
+///
+/// let op = OpBuilder::new(a, b).union();
+///
+/// let mut counter = Counter::default();
+/// SetOperation::<i32>::extend_collection(op, &mut counter);
+///
+/// assert_eq!(counter.0, 7);
+/// # Ok(()) }
+/// # try_main().unwrap();
+/// ```
+#[derive(Default)]
+pub struct Counter(pub usize);
+
+impl Counter {
+    /// Create a new [`Counter`] initialized with 0;
+    pub fn new() -> Counter {
+        Counter::default()
+    }
+}
+
+impl<T> Collection<T> for Counter {
+    fn push(&mut self, _elem: T) {
+        self.0 = self.0.saturating_add(1);
+    }
+
+    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
+        self.0 = self.0.saturating_add(elems.len());
+    }
+
+    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
+        self.0 = self.0.saturating_add(elems.into_iter().count());
+    }
+}

--- a/src/duo/difference.rs
+++ b/src/duo/difference.rs
@@ -1,5 +1,5 @@
 use crate::set::Set;
-use crate::{exponential_offset_ge, SetOperation};
+use crate::{exponential_offset_ge, SetOperation, Collection};
 
 /// Represent the _difference_ set operation that will be applied to two slices.
 ///
@@ -38,8 +38,9 @@ impl<'a, T> Difference<'a, T> {
 
 impl<'a, T: Ord> Difference<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, extend: F)
-    where F: Fn(&mut Vec<U>, &'a [T])
+    fn extend_collection<C, U, F>(mut self, output: &mut C, extend: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T])
     {
         while let Some(first) = self.a.first() {
             self.b = exponential_offset_ge(self.b, first);
@@ -63,14 +64,14 @@ impl<'a, T: Ord> Difference<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for Difference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Difference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/duo/difference_by_key.rs
+++ b/src/duo/difference_by_key.rs
@@ -1,5 +1,5 @@
 use crate::set::Set;
-use crate::{exponential_offset_ge_by_key, SetOperation};
+use crate::{exponential_offset_ge_by_key, SetOperation, Collection};
 
 /// Represent the _difference_ set operation that will be applied to two slices of different types.
 ///
@@ -69,8 +69,9 @@ where F: Fn(&T) -> K,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec<X, E>(mut self, output: &mut Vec<X>, extend: E)
-    where E: Fn(&mut Vec<X>, &'a [T]),
+    fn extend_collection<C, X, E>(mut self, output: &mut C, extend: E)
+    where C: Collection<X>,
+          E: Fn(&mut C, &'a [T]),
     {
         while let Some(first) = self.a.first().map(|x| (self.f)(x)) {
             self.b = exponential_offset_ge_by_key(self.b, &first, &self.g);
@@ -101,8 +102,8 @@ where T: Clone,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
@@ -111,8 +112,8 @@ where F: Fn(&T) -> K,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/duo/intersection.rs
+++ b/src/duo/intersection.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use crate::set::Set;
-use crate::{SetOperation, exponential_offset_ge};
+use crate::{exponential_offset_ge, SetOperation, Collection};
 
 /// Represent the _intersection_ set operation that will be applied to two slices.
 ///
@@ -39,8 +39,9 @@ impl<'a, T> Intersection<'a, T> {
 
 impl<'a, T: Ord> Intersection<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, extend: F)
-    where F: Fn(&mut Vec<U>, &'a [T])
+    fn extend_collection<C, U, F>(mut self, output: &mut C, extend: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T])
     {
         while !self.a.is_empty() && !self.b.is_empty() {
             let a = &self.a[0];
@@ -63,14 +64,14 @@ impl<'a, T: Ord> Intersection<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for Intersection<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Intersection<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/duo/symmetric_difference.rs
+++ b/src/duo/symmetric_difference.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use crate::set::Set;
-use crate::SetOperation;
+use crate::{SetOperation, Collection};
 
 /// Represent the _symmetric difference_ set operation that will be applied to two slices.
 ///
@@ -39,8 +39,9 @@ impl<'a, T> SymmetricDifference<'a, T> {
 
 impl<'a, T: Ord> SymmetricDifference<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, extend: F)
-    where F: Fn(&mut Vec<U>, &'a [T])
+    fn extend_collection<C, U, F>(mut self, output: &mut C, extend: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T])
     {
         loop {
             match (self.a.first(), self.b.first()) {
@@ -78,14 +79,14 @@ impl<'a, T: Ord> SymmetricDifference<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for SymmetricDifference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for SymmetricDifference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/duo/union.rs
+++ b/src/duo/union.rs
@@ -1,6 +1,6 @@
 use std::cmp::{self, Ordering};
 use crate::set::Set;
-use crate::SetOperation;
+use crate::{SetOperation, Collection};
 
 /// Represent the _union_ set operation that will be applied to two slices.
 ///
@@ -39,8 +39,9 @@ impl<'a, T> Union<'a, T> {
 
 impl<'a, T: Ord> Union<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, extend: F)
-    where F: Fn(&mut Vec<U>, &'a [T])
+    fn extend_collection<C, U, F>(mut self, output: &mut C, extend: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T])
     {
         let min_len = cmp::max(self.a.len(), self.b.len());
         output.reserve(min_len);
@@ -78,14 +79,14 @@ impl<'a, T: Ord> Union<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for Union<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Union<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,12 @@ extern crate serde;
 pub mod duo;
 pub mod multi;
 pub mod set;
+mod collection;
 mod two_minimums;
 
 use std::cmp::{self, Ordering};
 pub use crate::set::{Set, SetBuf, Error};
+pub use crate::collection::{Collection, Counter};
 
 /// Exponential searches this sorted slice for a given element.
 ///
@@ -203,70 +205,6 @@ where F: FnMut(&T) -> B,
       B: Ord,
 {
     exponential_offset_ge_by(slice, |x| f(x).cmp(b))
-}
-
-pub trait Collection<T> {
-    fn push(&mut self, elem: T);
-    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone;
-    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T>;
-    fn reserve(&mut self, size: usize) { }
-}
-
-impl<T> Collection<T> for Vec<T> {
-    fn push(&mut self, elem: T) {
-        Vec::push(self, elem);
-    }
-
-    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
-        Vec::extend_from_slice(self, elems);
-    }
-
-    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
-        Extend::extend(self, elems);
-    }
-
-    fn reserve(&mut self, size: usize) {
-        Vec::reserve(self, size);
-    }
-}
-
-/// A [`Collection`] that only counts the final size of a set operation.
-///
-/// It is meant to be used to avoid unecessary allocations.
-///
-/// ```
-/// # use sdset::Error;
-/// # fn try_main() -> Result<(), Error> {
-/// use sdset::duo::OpBuilder;
-/// use sdset::{SetOperation, Set, SetBuf, Counter};
-///
-/// let a = Set::new(&[1, 2, 4, 6, 7])?;
-/// let b = Set::new(&[2, 3, 4, 5, 6, 7])?;
-///
-/// let op = OpBuilder::new(a, b).union();
-///
-/// let mut counter = Counter::default();
-/// SetOperation::<i32>::extend_collection(op, &mut counter);
-///
-/// assert_eq!(counter.0, 7);
-/// # Ok(()) }
-/// # try_main().unwrap();
-/// ```
-#[derive(Default)]
-pub struct Counter(pub usize);
-
-impl<T> Collection<T> for Counter {
-    fn push(&mut self, elem: T) {
-        self.0 = self.0.saturating_add(1);
-    }
-
-    fn extend_from_slice(&mut self, elems: &[T]) where T: Clone {
-        self.0 = self.0.saturating_add(elems.len());
-    }
-
-    fn extend<I>(&mut self, elems: I) where I: IntoIterator<Item=T> {
-        self.0 = self.0.saturating_add(elems.into_iter().count());
-    }
 }
 
 /// Represent a type that can produce a set operation on multiple [`Set`]s.

--- a/src/multi/difference.rs
+++ b/src/multi/difference.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use crate::set::{Set, vec_sets_into_slices};
-use crate::{SetOperation, exponential_offset_ge};
+use crate::{SetOperation, Collection, exponential_offset_ge};
 
 /// Represent the _difference_ set operation that will be applied to the slices.
 ///
@@ -41,8 +41,9 @@ impl<'a, T> Difference<'a, T> {
 
 impl<'a, T: Ord> Difference<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, extend: F)
-    where F: Fn(&mut Vec<U>, &'a [T])
+    fn extend_collection<C, U, F>(mut self, output: &mut C, extend: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T])
     {
         let (base, others) = match self.slices.split_first_mut() {
             Some(split) => split,
@@ -78,14 +79,14 @@ impl<'a, T: Ord> Difference<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for Difference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice);
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice);
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Difference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend);
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend);
     }
 }
 

--- a/src/multi/difference_by_key.rs
+++ b/src/multi/difference_by_key.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use crate::set::{Set, vec_sets_into_slices};
-use crate::{SetOperation, exponential_offset_ge_by_key};
+use crate::{SetOperation, Collection, exponential_offset_ge_by_key};
 
 /// Represent the _difference_ set operation that will be applied to multiple slices
 /// of two different types.
@@ -72,8 +72,9 @@ where F: Fn(&T) -> K,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec<X, E>(mut self, output: &mut Vec<X>, extend: E)
-    where E: Fn(&mut Vec<X>, &'a [T]),
+    fn extend_collection<C, X, E>(mut self, output: &mut C, extend: E)
+    where C: Collection<X>,
+          E: Fn(&mut C, &'a [T]),
     {
         while let Some(first) = self.base.first().map(|x| (self.f)(x)) {
             let mut minimum = None;
@@ -118,8 +119,8 @@ where T: Clone,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice)
     }
 }
 
@@ -128,8 +129,8 @@ where F: Fn(&T) -> K,
       G: Fn(&U) -> K,
       K: Ord,
 {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend)
     }
 }
 

--- a/src/multi/intersection.rs
+++ b/src/multi/intersection.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use crate::set::{Set, vec_sets_into_slices};
-use crate::{SetOperation, exponential_offset_ge};
+use crate::{SetOperation, Collection, exponential_offset_ge};
 
 use self::Equality::*;
 
@@ -59,8 +59,9 @@ fn test_equality<'a, T: Ord>(slices: &[&'a [T]]) -> Equality<'a, T> {
 
 impl<'a, T: Ord> Intersection<'a, T> {
     #[inline]
-    fn extend_vec<U, F>(mut self, output: &mut Vec<U>, push: F)
-    where F: Fn(&mut Vec<U>, &'a T)
+    fn extend_collection<C, U, F>(mut self, output: &mut C, push: F)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a T)
     {
         if self.slices.is_empty() { return }
         if self.slices.iter().any(|s| s.is_empty()) { return }
@@ -86,14 +87,14 @@ impl<'a, T: Ord> Intersection<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for Intersection<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, |v, x| v.push(x.clone()))
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, |v, x| v.push(x.clone()))
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Intersection<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Vec::push)
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::push)
     }
 }
 

--- a/src/multi/symmetric_difference.rs
+++ b/src/multi/symmetric_difference.rs
@@ -1,6 +1,6 @@
 use crate::set::{Set, vec_sets_into_slices};
 use crate::two_minimums::{two_minimums, Minimums::*};
-use crate::SetOperation;
+use crate::{SetOperation, Collection};
 
 /// Represent the _symmetric difference_ set operation that will be applied to the slices.
 ///
@@ -38,9 +38,10 @@ impl<'a, T> SymmetricDifference<'a, T> {
 
 impl<'a, T: Ord> SymmetricDifference<'a, T> {
     #[inline]
-    fn extend_vec<U, F, G>(mut self, output: &mut Vec<U>, extend: F, push: G)
-    where F: Fn(&mut Vec<U>, &'a [T]),
-          G: Fn(&mut Vec<U>, &'a T),
+    fn extend_collection<C, U, F, G>(mut self, output: &mut C, extend: F, push: G)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T]),
+          G: Fn(&mut C, &'a T),
     {
         loop {
             match two_minimums(&self.slices) {
@@ -75,14 +76,14 @@ impl<'a, T: Ord> SymmetricDifference<'a, T> {
 }
 
 impl<'a, T: Ord + Clone> SetOperation<T> for SymmetricDifference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice, |v, x| v.push(x.clone()));
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice, |v, x| v.push(x.clone()));
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for SymmetricDifference<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend, Vec::push);
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend, Collection::push);
     }
 }
 

--- a/src/multi/union.rs
+++ b/src/multi/union.rs
@@ -1,6 +1,6 @@
 use crate::set::{Set, vec_sets_into_slices};
 use crate::two_minimums::{two_minimums, Minimums::*};
-use crate::SetOperation;
+use crate::{SetOperation, Collection};
 
 /// Represent the _union_ set operation that will be applied to the slices.
 ///
@@ -38,9 +38,10 @@ impl<'a, T> Union<'a, T> {
 
 impl<'a, T: Ord> Union<'a, T> {
     #[inline]
-    fn extend_vec<U, F, G>(mut self, output: &mut Vec<U>, extend: F, push: G)
-    where F: Fn(&mut Vec<U>, &'a [T]),
-          G: Fn(&mut Vec<U>, &'a T),
+    fn extend_collection<C, U, F, G>(mut self, output: &mut C, extend: F, push: G)
+    where C: Collection<U>,
+          F: Fn(&mut C, &'a [T]),
+          G: Fn(&mut C, &'a T),
     {
         if let Some(slice) = self.slices.first() {
             output.reserve(slice.len());
@@ -71,17 +72,15 @@ impl<'a, T: Ord> Union<'a, T> {
     }
 }
 
-
-
 impl<'a, T: Ord + Clone> SetOperation<T> for Union<'a, T> {
-    fn extend_vec(self, output: &mut Vec<T>) {
-        self.extend_vec(output, Vec::extend_from_slice, |v, x| v.push(x.clone()));
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<T> {
+        self.extend_collection(output, Collection::extend_from_slice, |v, x| v.push(x.clone()));
     }
 }
 
 impl<'a, T: Ord> SetOperation<&'a T> for Union<'a, T> {
-    fn extend_vec(self, output: &mut Vec<&'a T>) {
-        self.extend_vec(output, Extend::extend, Vec::push);
+    fn extend_collection<C>(self, output: &mut C) where C: Collection<&'a T> {
+        self.extend_collection(output, Collection::extend, Collection::push);
     }
 }
 


### PR DESCRIPTION
This trait is meant to abstract any collection type, like a `Vec` or a `VecDeque` for example.

In this pull request I also introduced a `Counter` struct that is a `Collection` and that allows us to only count the result length of a set operation, avoiding unecessary allocations 🎉