### PR TITLE
[Performance] reduce calls to exponential_offset_ge

### DIFF
--- a/bench_script.sh
+++ b/bench_script.sh
@@ -2,7 +2,7 @@
 
 # This env variable is here to permit
 # to use a custom `cargo bench` command if needed
-CARGO_BENCH_CMD=${CARGO_BENCH_CMD:-cargo bench}
+CARGO_BENCH_CMD=${CARGO_BENCH_CMD:-cargo bench --features unstable}
 
 if [ $# -eq 0 ]; then
     echo "comparing benchmarks of HEAD~1 and HEAD..."

--- a/src/duo/difference.rs
+++ b/src/duo/difference.rs
@@ -47,7 +47,9 @@ impl<'a, T: Ord> Difference<'a, T> {
             let minimum = self.b.first();
 
             match minimum {
-                Some(min) if min == first => self.a = exponential_offset_ge(&self.a[1..], min),
+                Some(min) if min == first => {
+                    self.a = &self.a[1..];
+                },
                 Some(min) => {
                     let off = self.a.iter().take_while(|&x| x < min).count();
                     extend(output, &self.a[..off])?;

--- a/src/duo/difference_by_key.rs
+++ b/src/duo/difference_by_key.rs
@@ -79,7 +79,7 @@ where F: Fn(&T) -> K,
             match self.b.first().map(|x| (self.g)(x)) {
                 Some(min) => {
                     if min == first {
-                        self.a = exponential_offset_ge_by_key(&self.a[1..], &min, &self.f)
+                        self.a = &self.a[1..];
                     } else {
                         let off = self.a.iter().take_while(|&x| (self.f)(x) < min).count();
                         extend(output, &self.a[..off])?;

--- a/src/duo/intersection.rs
+++ b/src/duo/intersection.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use crate::set::Set;
 use crate::{exponential_offset_ge, SetOperation, Collection};
 
@@ -54,10 +53,11 @@ impl<'a, T: Ord> Intersection<'a, T> {
                 self.a = &self.a[off..];
                 self.b = &self.b[off..];
             }
+            else if a < b {
+                self.a = exponential_offset_ge(self.a, b);
+            }
             else {
-                let max = cmp::max(a, b);
-                self.a = exponential_offset_ge(self.a, max);
-                self.b = exponential_offset_ge(self.b, max);
+                self.b = exponential_offset_ge(self.b, a);
             }
         }
         Ok(())

--- a/src/multi/difference.rs
+++ b/src/multi/difference.rs
@@ -62,7 +62,9 @@ impl<'a, T: Ord> Difference<'a, T> {
             }
 
             match minimum {
-                Some(min) if min == first => *base = exponential_offset_ge(&base[1..], min),
+                Some(min) if min == first => {
+                    *base = &base[1..];
+                },
                 Some(min) => {
                     let off = base.iter().take_while(|&x| x < min).count();
                     extend(output, &base[..off])?;

--- a/src/multi/difference_by_key.rs
+++ b/src/multi/difference_by_key.rs
@@ -96,7 +96,7 @@ where F: Fn(&T) -> K,
             match minimum {
                 Some(min) => {
                     if min == first {
-                        self.base = exponential_offset_ge_by_key(&self.base[1..], &min, &self.f);
+                        self.base = &self.base[1..];
                     } else {
                         let off = self.base.iter().take_while(|&x| (self.f)(x) < min).count();
                         extend(output, &self.base[..off])?;

--- a/src/multi/intersection.rs
+++ b/src/multi/intersection.rs
@@ -49,10 +49,14 @@ enum Equality<'a, T: 'a> {
 fn test_equality<'a, T: Ord>(slices: &[&'a [T]]) -> Equality<'a, T> {
     let mut is_equal = true;
     let mut max = &slices[0][0];
-    for x in slices {
-        let x = &x[0];
-        if is_equal { is_equal = max == x }
-        max = cmp::max(max, x);
+    for s in slices {
+        let x = &s[0];
+        if x != max {
+            is_equal = false;
+            if x > max {
+                max = x;
+            }
+        }
     }
     if is_equal { Equal(max) } else { NotEqual(max) }
 }
@@ -75,10 +79,12 @@ impl<'a, T: Ord> Intersection<'a, T> {
                         if slice.is_empty() { return Ok(()) }
                     }
                 },
-                NotEqual(x) => {
+                NotEqual(max) => {
                     for slice in &mut self.slices {
-                        *slice = exponential_offset_ge(slice, x);
-                        if slice.is_empty() { return Ok(()) }
+                        if &slice[0] != max {
+                            *slice = exponential_offset_ge(slice, max);
+                            if slice.is_empty() { return Ok(()) }
+                        }
                     }
                 }
             }

--- a/src/multi/intersection.rs
+++ b/src/multi/intersection.rs
@@ -47,18 +47,18 @@ enum Equality<'a, T: 'a> {
 
 #[inline]
 fn test_equality<'a, T: Ord>(slices: &[&'a [T]]) -> Equality<'a, T> {
-    let mut is_equal = true;
+    let mut is_equal: usize = 1; // LLVM produced wasted instruction when this was bool
     let mut max = &slices[0][0];
     for s in slices {
         let x = &s[0];
         if x != max {
-            is_equal = false;
-            if x > max {
-                max = x;
-            }
+            is_equal = 0;
+        }
+        if x > max {
+            max = x;
         }
     }
-    if is_equal { Equal(max) } else { NotEqual(max) }
+    if is_equal != 0 { Equal(max) } else { NotEqual(max) }
 }
 
 impl<'a, T: Ord> Intersection<'a, T> {


### PR DESCRIPTION
For difference / difference_by_key:
If the data is sorted and deduplicated, then the next element that will be greater than the current element is simply the next element.

For intersection:
Don't need to call exponential_offset_ge on the slice pointer(s) that are known to already be at the max value.

All tests pass, and I ran the benchmark several times and observed consistent performance improvements in the affected operations.
| Bench | Old | New |
|-------|-----|-----|
| duo::difference::bench::two_slices_big                | 324 ns/iter (+/- 1) | 179 ns/iter (+/- 1) |
| duo::difference::bench::two_slices_big2               | 189 ns/iter (+/- 2) | 117 ns/iter (+/- 5) |
| duo::difference::bench::two_slices_big3               |  63 ns/iter (+/- 2) |  57 ns/iter (+/- 1) |
| duo::difference_by_key::bench::two_slices_big         | 324 ns/iter (+/- 16) | 174 ns/iter (+/- 1) |
| duo::difference_by_key::bench::two_slices_big2        | 204 ns/iter (+/- 10) | 130 ns/iter (+/- 1) |
| duo::difference_by_key::bench::two_slices_big3        |  88 ns/iter (+/- 0) |  88 ns/iter (+/- 0) |
| duo::intersection::bench::two_slices_big              |  67 ns/iter (+/- 0) |  57 ns/iter (+/- 2) |
| duo::intersection::bench::two_slices_big2             |  44 ns/iter (+/- 1) |  36 ns/iter (+/- 4) |
| duo::intersection::bench::two_slices_big3             |  10 ns/iter (+/- 0) |   9 ns/iter (+/- 0) |
| duo::symmetric_difference::bench::two_slices_big      |  66 ns/iter (+/- 0) |  66 ns/iter (+/- 0) |
| duo::symmetric_difference::bench::two_slices_big2     |  93 ns/iter (+/- 2) |  89 ns/iter (+/- 2) |
| duo::symmetric_difference::bench::two_slices_big3     |  96 ns/iter (+/- 1) |  96 ns/iter (+/- 2) |
| duo::union::bench::two_slices_big                     |  98 ns/iter (+/- 1) |  99 ns/iter (+/- 1) |
| duo::union::bench::two_slices_big2                    |  83 ns/iter (+/- 1) |  86 ns/iter (+/- 2) |
| duo::union::bench::two_slices_big3                    |  76 ns/iter (+/- 1) |  77 ns/iter (+/- 2) |
| multi::difference::bench::three_slices_big            | 628 ns/iter (+/- 2) | 482 ns/iter (+/- 3) |
| multi::difference::bench::three_slices_big2           | 470 ns/iter (+/- 3) | 373 ns/iter (+/- 13) |
| multi::difference::bench::three_slices_big3           |  68 ns/iter (+/- 1) |  67 ns/iter (+/- 2) |
| multi::difference::bench::two_slices_big              | 423 ns/iter (+/- 1) | 273 ns/iter (+/- 6) |
| multi::difference::bench::two_slices_big2             | 242 ns/iter (+/- 2) | 167 ns/iter (+/- 3) |
| multi::difference::bench::two_slices_big3             |  64 ns/iter (+/- 1) |  64 ns/iter (+/- 1) |
| multi::difference_by_key::bench::three_slices_big     | 646 ns/iter (+/- 1) | 459 ns/iter (+/- 22) |
| multi::difference_by_key::bench::three_slices_big2    | 490 ns/iter (+/- 3) | 382 ns/iter (+/- 9) |
| multi::difference_by_key::bench::three_slices_big3    | 105 ns/iter (+/- 2) | 105 ns/iter (+/- 2) |
| multi::difference_by_key::bench::two_slices_big       | 444 ns/iter (+/- 5) | 293 ns/iter (+/- 1) |
| multi::difference_by_key::bench::two_slices_big2      | 272 ns/iter (+/- 1) | 197 ns/iter (+/- 2) |
| multi::difference_by_key::bench::two_slices_big3      | 103 ns/iter (+/- 2) | 103 ns/iter (+/- 2) |
| multi::intersection::bench::three_slices_big          | 587 ns/iter (+/- 10) | 572 ns/iter (+/- 4) |
| multi::intersection::bench::three_slices_big2         | 278 ns/iter (+/- 5) | 273 ns/iter (+/- 2) |
| multi::intersection::bench::three_slices_big3         |  26 ns/iter (+/- 0) |  26 ns/iter (+/- 0) |
| multi::intersection::bench::two_slices_big            | 491 ns/iter (+/- 7) | 455 ns/iter (+/- 4) |
| multi::intersection::bench::two_slices_big2           | 300 ns/iter (+/- 6) | 282 ns/iter (+/- 4) |
| multi::intersection::bench::two_slices_big3           |  23 ns/iter (+/- 0) |  23 ns/iter (+/- 1) |
| multi::symmetric_difference::bench::three_slices_big  | 935 ns/iter (+/- 24) | 854 ns/iter (+/- 34) |
| multi::symmetric_difference::bench::three_slices_big2 | 772 ns/iter (+/- 19) | 725 ns/iter (+/- 27) |
| multi::symmetric_difference::bench::three_slices_big3 | 148 ns/iter (+/- 3) | 147 ns/iter (+/- 5) |
| multi::symmetric_difference::bench::two_slices_big    | 501 ns/iter (+/- 3) | 475 ns/iter (+/- 13) |
| multi::symmetric_difference::bench::two_slices_big2   | 313 ns/iter (+/- 13) | 304 ns/iter (+/- 24) |
| multi::symmetric_difference::bench::two_slices_big3   |  95 ns/iter (+/- 2) |  95 ns/iter (+/- 2) |
| multi::union::bench::three_slices_big                 | 822 ns/iter (+/- 58) | 820 ns/iter (+/- 34) |
| multi::union::bench::three_slices_big2                | 796 ns/iter (+/- 30) | 775 ns/iter (+/- 32) |
| multi::union::bench::three_slices_big3                | 156 ns/iter (+/- 5) | 154 ns/iter (+/- 6) |
| multi::union::bench::two_slices_big                   | 650 ns/iter (+/- 23) | 589 ns/iter (+/- 22) |
| multi::union::bench::two_slices_big2                  | 368 ns/iter (+/- 12) | 338 ns/iter (+/- 11) |
| multi::union::bench::two_slices_big3                  |  94 ns/iter (+/- 1) |  96 ns/iter (+/- 6) |