### PR TITLE
additional performance enhancement

### DIFF
--- a/src/duo/difference.rs
+++ b/src/duo/difference.rs
@@ -49,6 +49,7 @@ impl<'a, T: Ord> Difference<'a, T> {
             match minimum {
                 Some(min) if min == first => {
                     self.a = &self.a[1..];
+                    self.b = &self.b[1..];
                 },
                 Some(min) => {
                     let off = self.a.iter().take_while(|&x| x < min).count();


### PR DESCRIPTION
For duo difference, when a.first() == b.first(), advance both slices by 1 before the next loop.

Relevant performance diff:
`./bench_script.sh bf73ba38c6d15a045cd6c84850a860eb49229a48 bb430a2b987b59fa6bf40457cebb70e092a13e1e`
```
duo::difference::bench::two_slices_big                93                     83                              -10  -10.75%   x 1.12 
duo::difference::bench::two_slices_big2               67                     62                               -5   -7.46%   x 1.08 
```